### PR TITLE
Revert MCQ question commit (#76) (#78)

### DIFF
--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/managers/UpdateHierarchyManager.scala
@@ -71,62 +71,6 @@ object UpdateHierarchyManager {
                 .getOrDefault(HierarchyConstants.OBJECT_TYPE, "").asInstanceOf[String], "Question"))
                 throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Question cannot have children in hierarchy")
         })
-        val iterator = nodesModified.entrySet().iterator()
-        while (iterator.hasNext) {
-            val entry = iterator.next()
-            val questionData = entry.getValue() match {
-                case map: java.util.HashMap[_, _] => map.asInstanceOf[java.util.HashMap[String, AnyRef]]
-                case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Invalid question data.")
-            }
-            val metadata = Option(questionData.get(HierarchyConstants.METADATA)) match {
-                case Some(map: java.util.HashMap[_, _]) => map.asInstanceOf[java.util.HashMap[String, AnyRef]]
-                case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing metadata.")
-            }
-            if (metadata.get(HierarchyConstants.PRIMARY_CATEGORY) == HierarchyConstants.MCQ) {
-                val primaryCategory = Option(metadata.get(HierarchyConstants.PRIMARY_CATEGORY)) match {
-                    case Some(category: String) => category
-                    case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing primary category.")
-                }
-
-                if (primaryCategory == HierarchyConstants.MCQ) {
-                    val choices = Option(metadata.get(HierarchyConstants.CHOICES)) match {
-                        case Some(choiceMap: java.util.HashMap[_, _]) =>
-                            val options = Option(choiceMap.get(HierarchyConstants.OPTIONS)) match {
-                                case Some(optionsList: java.util.List[_]) =>
-                                    optionsList.asInstanceOf[java.util.List[java.util.HashMap[String, AnyRef]]].asScala.toList
-                                case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing options.")
-                            }
-                            options
-                        case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing choices.")
-                    }
-
-                    for (option <- choices) {
-                        val answerType = Option(option.get(HierarchyConstants.ANSWER)) match {
-                            case Some(answer) => answer
-                            case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing answer type.")
-                        }
-
-                        if (!answerType.isInstanceOf[java.lang.Boolean]) {
-                            val questionBody = Option(metadata.get(HierarchyConstants.BODY)) match {
-                                case Some(body: String) => body
-                                case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing question body.")
-                            }
-
-                            val optionBody = Option(option.get(HierarchyConstants.VALUE)) match {
-                                case Some(valueMap: java.util.HashMap[_, _]) =>
-                                    Option(valueMap.get(HierarchyConstants.BODY)) match {
-                                        case Some(body) => body
-                                        case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing option body.")
-                                    }
-                                case _ => throw new ClientException("ERR_QS_UPDATE_HIERARCHY", "Error: Missing option value map.")
-                            }
-
-                            throw new ClientException("ERR_QS_UPDATE_HIERARCHY", s"Error: Question : '$questionBody', Option : '$optionBody' has a non-boolean answer. The answer value should be either true or false.")
-                        }
-                    }
-                }
-            }
-        }
         (nodesModified, hierarchy)
     }
 

--- a/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyConstants.scala
+++ b/assessment-api/qs-hierarchy-manager/src/main/scala/org/sunbird/utils/HierarchyConstants.scala
@@ -57,13 +57,4 @@ object HierarchyConstants {
     val SOURCE: String = "source"
     val PRE_CONDITION: String = "preCondition"
     val QUESTION_VISIBILITY: List[String] = List("Default", "Parent")
-    val OPTIONS = "options"
-    val CHOICES = "choices"
-    val ANSWER = "answer"
-    val BODY = "body"
-    val VALUE = "value"
-    val PRIMARY_CATEGORY = "primaryCategory"
-    val MCQ = "Multiple Choice Question"
-
-
 }


### PR DESCRIPTION
* Revert "Adding constant value for MCQ - review changes"

This reverts commit ddd6136ee037c835d1b2a945074391a5e1f30e8f.

* Revert "Adding constant value for MCQ - review changes"

This reverts commit 6c587bcf5cfd20dc666d01bb3307d3d4d71adb7f.

* Revert "Review changes"

This reverts commit f39c77837a92782d2e8008921986b98e4de790f4.

* Revert "Additional check on MCQ questions"

This reverts commit 93cde23b99bacd654407b0e368790a7ff511746c.

* Revert "Validations to ensure boolean input for MCQ answers"

This reverts commit 3eeefb3f053b6d3001b53e8da95a7ec2505c00bc.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

